### PR TITLE
Remove explicit reference to the build/bundle from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8">
-        <title>FriendChies</title>
-    </head>
-    <body>
-        <div id="root"></div>
-        <script src="build/bundle.js"></script>
-    </body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>FriendChies</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
 </html>


### PR DESCRIPTION
This will be created for us by webpack both in development and production. As a result, explicit references to the `build/bundle.js` as a script tag in the index.html will at best be redundant and at worst generate 404 requests when in development.